### PR TITLE
DM-51254: Initial implementation of cassandra backups using cassandra-medusa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(VENV_LOCATION) :
 	@echo "\n === Execute '. setup.sh' to activate environment ===\n"
 
 ansible : $(VENV_LOCATION)
-	. $(VENV_LOCATION)/bin/activate; pip install -r requirements.txt
+	. $(VENV_LOCATION)/bin/activate; python3 -m pip install -r requirements.txt
 
 collections : ansible
 	. $(VENV_LOCATION)/bin/activate; ansible-galaxy collection install -r collections.yml

--- a/bin/medusa-backup
+++ b/bin/medusa-backup
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+
+from lsst.dax.apdb_deploy.cli import medusa_backup
+
+if __name__ == "__main__":
+    sys.exit(medusa_backup.main())

--- a/cassandra_cluster/group_vars/all.yml
+++ b/cassandra_cluster/group_vars/all.yml
@@ -19,7 +19,7 @@ jolokia_version: 1.7.2
 
 # Location on controller node used to cache various files.
 local_cache: "{{ playbook_dir }}/.cache"
-group_local_cache: '{{ playbook_dir }}/.cache/{{ cluster_group_name | default("_any_") }}'
+group_local_cache: '{{ playbook_dir }}/.cache/{{ cluster_unique_id | default("_any_") }}'
 
 # Directory for data on remote host, it must be created before cluster is
 # deployed, and its ownership needs to be set to UID=999. Individual clusters
@@ -55,5 +55,29 @@ cluster_seed_hosts_names: >-
     {{ hostvars[h].ansible_host }}
   {%- endfor -%}
 
-# UID of the cassandra user in Docker container.
+# UID of the cassandra user in Docker containers (both cassandra and medusa).
 cassandra_user_uid: "999"
+
+#
+# Backup-related options.
+#
+
+# Must be set to true to enable support medusa backups.
+use_backups: false
+
+medusa_image_name: k8ssandra/medusa
+medusa_version: 0.25.0
+
+backup_service_name: medusa
+backup_storage_provider: s3_compatible
+backup_bucket_name: usdf-apdb-prod
+backup_aws_key_file: /run/secrets/aws-credentials.ini
+backup_hashi_vault_aws_path: rubin/usdf-apdb-prod/s3
+backup_prefix: medusa_backup_{{ cluster_unique_id }}
+backup_transfer_max_bandwidth: 500MB/s
+backup_concurrent_transfers: 1
+backup_s3_host: s3dfrgw.slac.stanford.edu
+backup_s3_port: 443
+
+# Jolokia is needed for both monitoring and backups.
+need_jolokia: "{{ use_monitoring or use_backups }}"

--- a/cassandra_cluster/group_vars/all.yml
+++ b/cassandra_cluster/group_vars/all.yml
@@ -71,7 +71,7 @@ medusa_version: 0.25.0
 backup_service_name: medusa
 backup_storage_provider: s3_compatible
 backup_bucket_name: usdf-apdb-prod
-backup_aws_key_file: /run/secrets/aws-credentials.ini
+backup_aws_key_file: /run/secrets/medusa-minio-credentials
 backup_hashi_vault_aws_path: rubin/usdf-apdb-prod/s3
 backup_prefix: medusa_backup_{{ cluster_unique_id }}
 backup_transfer_max_bandwidth: 500MB/s

--- a/cassandra_cluster/group_vars/apdb_dev.yml
+++ b/cassandra_cluster/group_vars/apdb_dev.yml
@@ -4,8 +4,11 @@ cluster_unique_id: "apdb_dev"
 deploy_folder: "/sdf/home/s/{{ lookup('ansible.builtin.env', 'USER') }}/apdb_deploy"
 data_dir: "/zfspool/cassandra/test-apdb-cluster"
 logs_dir: "/zfspool/cassandra/logs"
+
 use_password: true
 credentials_source: "hashi_vault"
 hashi_vault_user_path: "rubin/usdf-apdb-dev/apdb-prod"
-hashi_vault_super_path: "rubin/usdf-apdb-dev/apdb-prod"
+hashi_vault_super_path: "rubin/usdf-apdb-dev/cassandra-super"
 hashi_vault_mount_point: "secret"
+
+use_backups: true

--- a/cassandra_cluster/group_vars/apdb_dev.yml
+++ b/cassandra_cluster/group_vars/apdb_dev.yml
@@ -1,6 +1,6 @@
 ---
 cluster_name: "APDB USDF test"
-cluster_group_name: "apdb_dev"
+cluster_unique_id: "apdb_dev"
 deploy_folder: "/sdf/home/s/{{ lookup('ansible.builtin.env', 'USER') }}/apdb_deploy"
 data_dir: "/zfspool/cassandra/test-apdb-cluster"
 logs_dir: "/zfspool/cassandra/logs"

--- a/cassandra_cluster/group_vars/apdb_test.yml
+++ b/cassandra_cluster/group_vars/apdb_test.yml
@@ -1,6 +1,6 @@
 ---
-cluster_name: "APDB USDF test"
-cluster_group_name: "apdb_test"
+cluster_name: "USDF APDB Test Cluster"
+cluster_unique_id: "apdb_test"
 deploy_folder: "/sdf/home/s/{{ lookup('ansible.builtin.env', 'USER') }}/apdb_deploy"
 data_dir: "/zfspool/cassandra/test-apdb-cluster"
 logs_dir: "/zfspool/cassandra/logs"
@@ -9,3 +9,5 @@ credentials_source: "hashi_vault"
 hashi_vault_user_path: "rubin/usdf-apdb-dev/apdb-prod"
 hashi_vault_super_path: "rubin/usdf-apdb-dev/apdb-prod"
 hashi_vault_mount_point: "secret"
+
+use_backups: true

--- a/cassandra_cluster/group_vars/apdb_test.yml
+++ b/cassandra_cluster/group_vars/apdb_test.yml
@@ -4,10 +4,11 @@ cluster_unique_id: "apdb_test"
 deploy_folder: "/sdf/home/s/{{ lookup('ansible.builtin.env', 'USER') }}/apdb_deploy"
 data_dir: "/zfspool/cassandra/test-apdb-cluster"
 logs_dir: "/zfspool/cassandra/logs"
+
 use_password: true
 credentials_source: "hashi_vault"
-hashi_vault_user_path: "rubin/usdf-apdb-dev/apdb-prod"
-hashi_vault_super_path: "rubin/usdf-apdb-dev/apdb-prod"
+hashi_vault_user_path: "rubin/usdf-apdb-test/cassandra"
+hashi_vault_super_path: "rubin/usdf-apdb-test/cassandra-super"
 hashi_vault_mount_point: "secret"
 
 use_backups: true

--- a/cassandra_cluster/roles/cassandra_configs/tasks/main.yml
+++ b/cassandra_cluster/roles/cassandra_configs/tasks/main.yml
@@ -51,10 +51,10 @@
       ansible.builtin.set_fact:
         c8_yaml: "{{ c8_yaml_orig | merge_yaml_strings(c8_yaml_local) }}"
 
-    - name: "Save cassandra.yaml to local cache"
+    - name: "Save cassandra.yaml.j2 to local cache"
       ansible.builtin.copy:
         content: "{{ c8_yaml }}"
-        dest: "{{ group_local_cache }}/cassandra-{{ cassandra_version }}.yaml"
+        dest: "{{ group_local_cache }}/cassandra-{{ cassandra_version }}.yaml.j2"
         mode: "644"
 
     - name: "Copy jvm-server.options files"

--- a/cassandra_cluster/roles/cassandra_configs/templates/cassandra-local.yaml.j2
+++ b/cassandra_cluster/roles/cassandra_configs/templates/cassandra-local.yaml.j2
@@ -2,6 +2,12 @@
 # Overrides for default values in cassandra.yaml
 #
 
+# Cassandra will listen_address in any case internally, but for medusa we
+# need the name of the host (not localhost) here. This file is first processed
+# locally and then we do another transform when copying it to remote, thios is
+# why "raw" is here.
+listen_address: '"{% raw %}{{ ansible_host }}{% endraw %}"'
+
 authenticator: {{ "PasswordAuthenticator" if use_password else "AllowAllAuthenticator" }}
 authorizer: {{ "CassandraAuthorizer" if use_password else "AllowAllAuthorizer" }}
 

--- a/cassandra_cluster/roles/cassandra_files/tasks/main.yml
+++ b/cassandra_cluster/roles/cassandra_files/tasks/main.yml
@@ -31,7 +31,12 @@
   loop:
     - "{{ cassandra_files_jvm_server_options }}"
     - "{{ cassandra_files_jvm11_server_options }}"
-    - "{{ cassandra_files_cassandra_yaml }}"
+
+- name: "Copy cassandra config file"
+  ansible.builtin.template:
+    src: "{{ group_local_cache }}/{{ cassandra_files_cassandra_yaml }}.j2"
+    dest: "{{ deploy_docker_folder }}/{{ cassandra_files_cassandra_yaml }}"
+    mode: "644"
 
 - name: "Copy cqlsh and nodetool wrapper to cluster"
   ansible.builtin.template:

--- a/cassandra_cluster/roles/cassandra_files/tasks/main.yml
+++ b/cassandra_cluster/roles/cassandra_files/tasks/main.yml
@@ -15,7 +15,7 @@
     mode: "755"
 
 - name: "Optionally copy Jolokia agent JAR to cluster"
-  when: use_monitoring
+  when: need_jolokia
   block:
     - name: "Copy Jolokia agent JAR to cluster"
       ansible.builtin.copy:

--- a/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
+++ b/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
@@ -28,7 +28,7 @@ services:
       - type: bind
         source: {{ logs_dir }}
         target: /var/log/cassandra
-      {% if use_monitoring -%}
+      {% if need_jolokia -%}
       - type: bind
         source: "{{ deploy_docker_folder }}/{{ cassandra_files_jolokia_jar }}"
         target: /opt/cassandra/lib/jolokia-jvm.jar
@@ -38,7 +38,7 @@ services:
     environment:
       CASSANDRA_SEEDS: "{{ cluster_seed_hosts_names }}"
       CASSANDRA_CLUSTER_NAME: "{{ cluster_name | default('APDB_TEST') }}"
-      {% if use_monitoring -%}
+      {% if need_jolokia -%}
       JVM_EXTRA_OPTS: "-javaagent:/opt/cassandra/lib/jolokia-jvm.jar=port=8778,host=localhost"
       {%- endif %}
 
@@ -57,6 +57,49 @@ services:
       - cassandra_yaml
 
     command: ["/entrypoint-wrapper.sh", "cassandra", "-f"]
+
+{% if use_backups %}
+
+  "{{ backup_service_name }}":
+
+    image: {{ medusa_image_name }}:{{ medusa_version }}
+
+    network_mode: "host"
+    restart: "on-failure:7"
+
+    volumes:
+      - type: bind
+        source: {{ data_dir }}
+        target: /var/lib/cassandra
+      - type: bind
+        source: "{{ deploy_docker_folder }}/cassandra-{{ cassandra_version }}.yaml"
+        target: /etc/cassandra/cassandra.yaml
+        read_only: true
+      - type: bind
+        source: "{{ deploy_docker_folder }}/medusa.ini"
+        target: /etc/medusa/medusa.ini
+        read_only: true
+
+    environment:
+      MEDUSA_MODE: GRPC
+
+    secrets:
+      - source: medusa_aws_credentials
+        target: medusa-minio-credentials
+        # docker-compose does not support uid/gid
+        # uid: "999"
+        # gid: "999"
+        # mode: 0o400
+
+{% endif %}
+
+{% if use_backups %}
+
+secrets:
+  medusa_aws_credentials:
+    file: "{{ deploy_docker_folder }}/medusa-minio-credentials"
+
+{% endif %}
 
 configs:
   cassandra_yaml:

--- a/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
+++ b/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
@@ -82,6 +82,10 @@ services:
 
     environment:
       MEDUSA_MODE: GRPC
+      PYTHONWARNINGS: "ignore:Unverified HTTPS request"
+
+    env_file:
+      - "{{ deploy_docker_folder }}/medusa-cassandra-credentials.env"
 
     secrets:
       - source: medusa_aws_credentials

--- a/cassandra_cluster/roles/jolokia_download/tasks/main.yml
+++ b/cassandra_cluster/roles/jolokia_download/tasks/main.yml
@@ -3,7 +3,7 @@
 # tasks file for roles/jolokia
 
 - name: "Download Jolokia to cache folder"
-  when: use_monitoring
+  when: need_jolokia
   delegate_to: localhost
   block:
     - name: "Create local cache folder"

--- a/cassandra_cluster/roles/medusa_configs/README.md
+++ b/cassandra_cluster/roles/medusa_configs/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/cassandra_cluster/roles/medusa_configs/defaults/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/defaults/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# defaults file for roles/medusa_configs

--- a/cassandra_cluster/roles/medusa_configs/handlers/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/handlers/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for roles/medusa_configs

--- a/cassandra_cluster/roles/medusa_configs/meta/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/meta/main.yml
@@ -1,0 +1,35 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/cassandra_cluster/roles/medusa_configs/tasks/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/tasks/main.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT-0
+---
+# tasks file for roles/medusa_configs
+
+- name: "Generate config files for cassandra-medusa"
+  block:
+
+    - name: "Ask Vault for AWKS secrets"
+      delegate_to: localhost
+      when: credentials_source == "hashi_vault"
+      block:
+        # Get some secrets from the Vault, runs on localhost, so use lookup
+        # plugin instead of module.
+        - name: "Ask Vault for AWS credentials"
+          ansible.builtin.set_fact:
+            hashi_response: "{{ lookup('community.hashi_vault.vault_kv2_get', '{{ backup_hashi_vault_aws_path }}', mount_point='{{ hashi_vault_mount_point }}') }}"
+
+        - name: "Extract credentials"
+          ansible.builtin.set_fact:
+            medusa_aws_access_key: "{{ hashi_response.data.data.access_key }}"
+            medusa_aws_secret_key: "{{ hashi_response.data.data.secret_key }}"
+
+    - name: "Copy AWS secret to cluster"
+      ansible.builtin.template:
+        src: "medusa-minio-credentials.j2"
+        dest: "{{ deploy_docker_folder }}/medusa-minio-credentials"
+        mode: 0o600
+
+    - name: "Set AWS secret ACL"
+      ansible.posix.acl:
+        path: "{{ deploy_docker_folder }}/medusa-minio-credentials"
+        etype: user
+        entity: "{{ cassandra_user_uid }}"
+        permissions: r
+        state: present
+
+    - name: "Copy medusa config to cluster"
+      ansible.builtin.template:
+        src: "medusa.ini.j2"
+        dest: "{{ deploy_docker_folder }}/medusa.ini"
+        mode: "644"
+
+  when: use_backups

--- a/cassandra_cluster/roles/medusa_configs/tasks/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: "Generate config files for cassandra-medusa"
   block:
 
-    - name: "Ask Vault for AWKS secrets"
+    - name: "Ask Vault for AWS secrets"
       delegate_to: localhost
       when: credentials_source == "hashi_vault"
       block:
@@ -41,3 +41,29 @@
         mode: "644"
 
   when: use_backups
+
+- name: "Copy cassandra credentials to the host."
+  block:
+
+    - name: "Ask Vault for Cassandra secrets"
+      delegate_to: localhost
+      when: credentials_source == "hashi_vault"
+      block:
+        # Get some secrets from the Vault, runs on localhost, so use lookup
+        # plugin instead of module.
+        - name: "Ask Vault for AWS credentials"
+          ansible.builtin.set_fact:
+            hashi_response: "{{ lookup('community.hashi_vault.vault_kv2_get', '{{ hashi_vault_super_path }}', mount_point='{{ hashi_vault_mount_point }}') }}"
+
+        - name: "Extract credentials"
+          ansible.builtin.set_fact:
+            cassandra_super_username: "{{ hashi_response.data.data.username }}"
+            cassandra_super_password: "{{ hashi_response.data.data.password }}"
+
+    - name: "Copy Cassandra secret to cluster"
+      ansible.builtin.template:
+        src: "medusa-cassandra-credentials.env.j2"
+        dest: "{{ deploy_docker_folder }}/medusa-cassandra-credentials.env"
+        mode: 0o600
+
+  when: use_password

--- a/cassandra_cluster/roles/medusa_configs/templates/medusa-cassandra-credentials.env.j2
+++ b/cassandra_cluster/roles/medusa_configs/templates/medusa-cassandra-credentials.env.j2
@@ -1,0 +1,2 @@
+MEDUSA_CQL_USERNAME={{ cassandra_super_username }}
+MEDUSA_CQL_PASSWORD={{ cassandra_super_password }}

--- a/cassandra_cluster/roles/medusa_configs/templates/medusa-minio-credentials.j2
+++ b/cassandra_cluster/roles/medusa_configs/templates/medusa-minio-credentials.j2
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = {{ medusa_aws_access_key }}
+aws_secret_access_key = {{ medusa_aws_secret_key }}

--- a/cassandra_cluster/roles/medusa_configs/templates/medusa.ini.j2
+++ b/cassandra_cluster/roles/medusa_configs/templates/medusa.ini.j2
@@ -47,7 +47,7 @@ config_file = /etc/cassandra/cassandra.yaml
 ; Disabling this can help when fqdn resolving gives different domain names for local and remote nodes
 ; which makes backup succeed but Medusa sees them as incomplete.
 ; Defaults to True.
-resolve_ip_addresses = True
+; resolve_ip_addresses = True
 
 ; When true, almost all commands executed by Medusa are prefixed with `sudo`.
 ; Does not affect the use_sudo_for_restore setting in the 'storage' section.
@@ -93,7 +93,7 @@ max_backup_count = 0
 ; Both thresholds can be defined for backup purge.
 
 ; Used to throttle S3 backups/restores:
-transfer_max_bandwidth = "{{ backup_transfer_max_bandwidth }}"
+transfer_max_bandwidth = {{ backup_transfer_max_bandwidth }}
 
 ; Max number of concurrent downloads/uploads.
 concurrent_transfers = {{ backup_concurrent_transfers }}
@@ -161,7 +161,7 @@ secure = True
 ; Controls file logging, disabled by default.
 ; enabled = 0
 ; file = medusa.log
-; level = INFO
+level = DEBUG
 
 ; Control the log output format
 ; format = [%(asctime)s] %(levelname)s: %(message)s
@@ -183,7 +183,7 @@ enabled = True
 [kubernetes]
 ; The following settings are only intended to be configured if Medusa is running in containers, preferably in Kubernetes.
 enabled = True
-cassandra_url = http://127.0.0.1:8778/
+cassandra_url = http://127.0.0.1:8778/jolokia/
 
 ; Enables the use of the management API to create snapshots. Falls back to using Jolokia if not enabled.
 ;use_mgmt_api = True

--- a/cassandra_cluster/roles/medusa_configs/templates/medusa.ini.j2
+++ b/cassandra_cluster/roles/medusa_configs/templates/medusa.ini.j2
@@ -1,0 +1,194 @@
+; Copyright 2019 Spotify AB. All rights reserved.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+; http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[cassandra]
+;stop_cmd = /etc/init.d/cassandra stop
+;start_cmd = /etc/init.d/cassandra start
+config_file = /etc/cassandra/cassandra.yaml
+;cql_username = <username>
+;cql_password = <password>
+; When using the following setting there must be files in:
+; - `<cql_k8s_secrets_path>/username` containing username
+; - `<cql_k8s_secrets_path>/password` containing password
+;cql_k8s_secrets_path = <path to kubernetes secrets folder>
+;nodetool_username =  <my nodetool username>
+;nodetool_password =  <my nodetool password>
+;nodetool_password_file_path = <path to nodetool password file>
+;nodetool_k8s_secrets_path = <path to nodetool kubernetes secrets folder>
+;nodetool_host = <host name or IP to use for nodetool>
+;nodetool_port = <port number to use for nodetool>
+;certfile= <Client SSL: path to rootCa certificate>
+;usercert= <Client SSL: path to user certificate>
+;userkey= <Client SSL: path to user key>
+;sstableloader_ts = <Client SSL: full path to truststore>
+;sstableloader_tspw = <Client SSL: password of the truststore>
+;sstableloader_ks = <Client SSL: full path to keystore>
+;sstableloader_kspw = <Client SSL: password of the keystore>
+;sstableloader_bin = <Location of the sstableloader binary if not in PATH>
+
+; Enable this to add the '--ssl' parameter to nodetool. The nodetool-ssl.properties is expected to be in the normal location
+;nodetool_ssl = true
+
+; Command ran to verify if Cassandra is running on a node. Defaults to "nodetool version"
+;check_running = nodetool version
+
+; Disable/Enable ip address resolving.
+; Disabling this can help when fqdn resolving gives different domain names for local and remote nodes
+; which makes backup succeed but Medusa sees them as incomplete.
+; Defaults to True.
+resolve_ip_addresses = True
+
+; When true, almost all commands executed by Medusa are prefixed with `sudo`.
+; Does not affect the use_sudo_for_restore setting in the 'storage' section.
+; See https://github.com/thelastpickle/cassandra-medusa/issues/318
+; Defaults to True
+use_sudo = False
+
+[storage]
+storage_provider = {{ backup_storage_provider }}
+; storage_provider should be either of "local", "google_storage", "azure_blobs" or the s3_* values from
+; https://github.com/apache/libcloud/blob/trunk/libcloud/storage/types.py
+
+; Storage class to use when uploading objects.
+; Use a value specific to chosen `storage_provider` that supports both reads and writes (eg S3's GLACIER and Azure's ARCHIVE won't work).
+; If not specified, we default to the 'hottest' class (STANDARD, STANDARD, HOT for GCP, AWS, AZURE respectively).
+; Supported values:
+; AWS S3: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING
+;    GCP: STANDARD |        Unsupported | Unsupported | Unsupported
+;  AZURE:      HOT |               COOL |        COLD
+; https://aws.amazon.com/s3/storage-classes/
+; https://cloud.google.com/storage/docs/storage-classes
+; https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview
+; storage_class = <Storage Class Name used to store backups>
+
+; Name of the bucket used for storing backups
+bucket_name = {{ backup_bucket_name }}
+
+; JSON key file for service account with access to GCS bucket or AWS credentials file (home-dir/.aws/credentials)
+key_file = {{ backup_aws_key_file }}
+
+; Path of the local storage bucket (used only with 'local' storage provider)
+;base_path = /path/to/backups
+
+; Any prefix used for multitenancy in the same bucket
+prefix = {{ backup_prefix }}
+
+;fqdn = <enforce the name of the local node. Computed automatically if not provided.>
+
+; Number of days before backups are purged. 0 means backups don't get purged by age (default)
+max_backup_age = 0
+; Number of backups to retain. Older backups will get purged beyond that number. 0 means backups don't get purged by count (default)
+max_backup_count = 0
+; Both thresholds can be defined for backup purge.
+
+; Used to throttle S3 backups/restores:
+transfer_max_bandwidth = "{{ backup_transfer_max_bandwidth }}"
+
+; Max number of concurrent downloads/uploads.
+concurrent_transfers = {{ backup_concurrent_transfers }}
+
+; Size over which uploads will be using multi part uploads. Defaults to 20MB.
+multi_part_upload_threshold = 20971520
+
+; GC grace period for backed up files. Prevents race conditions between purge and running backups
+backup_grace_period_in_days = 10
+
+; When not using sstableloader to restore data on a node, Medusa will copy snapshot files from a
+; temporary location into the cassandra data directroy. Medusa will then attempt to change the
+; ownership of the snapshot files so the cassandra user can access them.
+; Depending on how users/file permissions are set up on the cassandra instance, the medusa user
+; may need elevated permissions to manipulate the files in the cassandra data directory.
+;
+; This option does NOT replace the `use_sudo` option under the 'cassandra' section!
+; See: https://github.com/thelastpickle/cassandra-medusa/pull/399
+;
+; Defaults to True
+use_sudo_for_restore = False
+
+;api_profile = <AWS profile to use>
+
+host = {{ backup_s3_host }}
+port = {{ backup_s3_port }}
+
+; Configures the use of SSL to connect to the object storage system.
+secure = True
+
+; Enables verification of certificates used in case secure is set to True.
+; Enabling this is not yet supported - we don't have a good way to configure paths to custom certificates.
+; ssl_verify = False
+
+; addressing style of s3
+; S3 supports two different ways to address a bucket, Virtual Host Style and Path Style.
+; you can choose from auto/path/virtual
+;s3_addressing_style = auto
+
+;aws_cli_path = <Location of the aws cli binary if not in PATH>
+
+; Read timeout in seconds for the storage provider. Not set by default.
+;read_timeout = 60
+
+[monitoring]
+;monitoring_provider = <Provider used for sending metrics. Currently just "local">
+
+[ssh]
+;username = <SSH username to use for restoring clusters>
+;key_file = <Path of SSH key for use for restoring clusters. Expected in PEM unencrypted format.>
+;port = <SSH port for use for restoring clusters. Default to port 22.
+;cert_file = <Path of public key signed certificate file to use for authentication. The corresponding private key must also be provided via key_file parameter>
+; Enables the usage of a 'login' shell which, among other things, loads user's profile files.
+;login_shell = False
+
+[checks]
+;health_check = <Which ports to check when verifying a node restored properly. Options are 'cql' (default), 'thrift', 'all'.>
+;query = <CQL query to run after a restore to verify it went OK>
+;expected_rows = <Number of rows expected to be returned when the query runs. Not checked if not specified.>
+;expected_result = <Coma separated string representation of values returned by the query. Checks only 1st row returned, and only if specified>
+;enable_md5_checks = <During backups and verify, use md5 calculations to determine file integrity (in addition to size, which is used by default)>
+
+
+[logging]
+; Controls file logging, disabled by default.
+; enabled = 0
+; file = medusa.log
+; level = INFO
+
+; Control the log output format
+; format = [%(asctime)s] %(levelname)s: %(message)s
+
+; Size over which log file will rotate
+; maxBytes = 20000000
+
+; How many log files to keep
+; backupCount = 50
+
+[grpc]
+; Set to true when running in grpc server mode.
+; Allows to propagate the exceptions instead of exiting the program.
+enabled = True
+
+; if needed, change the port the grpc server listens to
+;port = 50051
+
+[kubernetes]
+; The following settings are only intended to be configured if Medusa is running in containers, preferably in Kubernetes.
+enabled = True
+cassandra_url = http://127.0.0.1:8778/
+
+; Enables the use of the management API to create snapshots. Falls back to using Jolokia if not enabled.
+;use_mgmt_api = True
+;ca_cert = mutual_auth_ca.pem
+;tls_cert = mutual_auth_client.crt
+;tls_key = mutual_auth_client.key
+
+

--- a/cassandra_cluster/roles/medusa_configs/tests/inventory
+++ b/cassandra_cluster/roles/medusa_configs/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/cassandra_cluster/roles/medusa_configs/tests/test.yml
+++ b/cassandra_cluster/roles/medusa_configs/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/medusa_configs

--- a/cassandra_cluster/roles/medusa_configs/vars/main.yml
+++ b/cassandra_cluster/roles/medusa_configs/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for roles/medusa_configs

--- a/cassandra_cluster/site.yml
+++ b/cassandra_cluster/site.yml
@@ -17,4 +17,5 @@
 
   roles:
     - remote_folders
+    - medusa_configs
     - cassandra_files

--- a/python/lsst/dax/apdb_deploy/cli/medusa_backup.py
+++ b/python/lsst/dax/apdb_deploy/cli/medusa_backup.py
@@ -1,0 +1,105 @@
+import argparse
+
+from .. import scripts
+
+
+def main() -> int | None:
+    """CLI for interacting with medusa gRPC service(s)."""
+
+    parser = argparse.ArgumentParser()
+
+    subparsers = parser.add_subparsers(title="available subcommands", required=True)
+    _create_make_backup(subparsers)
+    _create_show_backups(subparsers)
+    _create_delete_backup(subparsers)
+
+    args = parser.parse_args()
+
+    kwargs = vars(args)
+    method = kwargs.pop("method")
+    method(**kwargs)
+
+
+def _create_show_backups(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("show-backups", help="Show existing backups.")
+    parser.add_argument(
+        "inventory", type=argparse.FileType(), help="Path to Ansible inventory file."
+    )
+    parser.add_argument(
+        "-g",
+        "--group",
+        default="",
+        help="Host group in inventory file, default is to use first group.",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=50051,
+        help="Medusa service port number, default: %(defalt)s.",
+    )
+    parser.set_defaults(method=scripts.medusa_show_backups)
+
+
+def _create_make_backup(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("make-backup", help="Make new backup.")
+    parser.add_argument(
+        "inventory", type=argparse.FileType(), help="Path to Ansible inventory file."
+    )
+    parser.add_argument(
+        "-g",
+        "--group",
+        default="",
+        help="Host group in inventory file, default is to use first group.",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=50051,
+        help="Medusa service port number, default: %(default)s.",
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        default=None,
+        help="Backup name, default is to use current time to construct a name.",
+    )
+    parser.add_argument(
+        "-f",
+        "--full",
+        default=False,
+        action="store_true",
+        help="Make full backup, default is incremental backup.",
+    )
+    parser.add_argument(
+        "-a",
+        "--async",
+        dest="_async",
+        default=False,
+        action="store_true",
+        help="Run backup in async mode.",
+    )
+    parser.set_defaults(method=scripts.medusa_make_backup)
+
+
+def _create_delete_backup(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("delete-backup", help="Delete existing backup.")
+    parser.add_argument(
+        "inventory", type=argparse.FileType(), help="Path to Ansible inventory file."
+    )
+    parser.add_argument("name", type=str, help="Backup name.")
+    parser.add_argument(
+        "-g",
+        "--group",
+        default="",
+        help="Host group in inventory file, default is to use first group.",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=50051,
+        help="Medusa service port number, default: %(default)s.",
+    )
+    parser.set_defaults(method=scripts.medusa_delete_backup)

--- a/python/lsst/dax/apdb_deploy/inventory.py
+++ b/python/lsst/dax/apdb_deploy/inventory.py
@@ -1,0 +1,17 @@
+
+import yaml
+
+class Inventory:
+
+    def __init__(self, file_obj: object):
+        inventory = yaml.safe_load(stream=file_obj)
+        assert isinstance(inventory, dict)
+        self._inventory = inventory
+
+    def get_host_names(self, group: str | None = None) -> list[str]:
+        if not group:
+            hosts = list(self._inventory.values())[0]["hosts"]
+        else:
+            hosts = self._inventory[group]["hosts"]
+
+        return [item["ansible_host"] for item in hosts.values()]

--- a/python/lsst/dax/apdb_deploy/scripts/__init__.py
+++ b/python/lsst/dax/apdb_deploy/scripts/__init__.py
@@ -1,0 +1,1 @@
+from ._medusa_backups import medusa_delete_backup, medusa_make_backup, medusa_show_backups

--- a/python/lsst/dax/apdb_deploy/scripts/_medusa_backups.py
+++ b/python/lsst/dax/apdb_deploy/scripts/_medusa_backups.py
@@ -1,0 +1,131 @@
+import asyncio
+from datetime import datetime, UTC
+from typing import TYPE_CHECKING
+
+from medusa.service.grpc.client import Client
+from medusa.service.grpc.medusa_pb2 import StatusType
+from prettytable import PrettyTable
+
+from ..inventory import Inventory
+
+
+def _status_fmt(status: int) -> str:
+    for name, value in StatusType.items():
+        if status == value:
+            return name
+    return "???"
+
+
+def _size_fmt(size: int, suffix: str = "B") -> str:
+    for unit in ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"):
+        if abs(size) < 1024.0:
+            return f"{size:3.1f}{unit}{suffix}"
+        size /= 1024.0
+    return f"{size:.1f}Yi{suffix}"
+
+
+def _time_fmt(time: int) -> str:
+    if time:
+        return datetime.fromtimestamp(time).isoformat(sep=" ")
+    else:
+        return ""
+
+
+def medusa_make_backup(
+    inventory: object, group: str | None, port: int, name: str | None, full: bool, _async: bool
+) -> None:
+    asyncio.run(
+        _make_backup(inventory=inventory, group=group, port=port, name=name, full=full, _async=_async)
+    )
+
+
+def medusa_show_backups(inventory: object, group: str | None, port: int) -> None:
+    asyncio.run(_show_backups(inventory=inventory, group=group, port=port))
+
+
+def medusa_delete_backup(inventory: object, name: str, group: str | None, port: int) -> None:
+    asyncio.run(_delete_backup(inventory=inventory, name=name, group=group, port=port))
+
+
+async def _make_backup(
+    *, inventory: object, group: str | None, port: int, name: str | None, full: bool, _async: bool
+) -> None:
+
+    mode = "full" if full else "differential"
+    if not name:
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        name = f"{ts}-{mode}"
+
+    inv = Inventory(inventory)
+    hosts = inv.get_host_names(group)
+
+    backups = {}
+    for host in hosts:
+        contact = f"{host}:{port}"
+        client = Client(contact)
+        if _async:
+            backups[host] = asyncio.create_task(client.async_backup(name, mode))
+        else:
+            backups[host] = asyncio.create_task(client.backup(name, mode))
+
+    for host, backup in backups.items():
+        await backup
+
+
+async def _show_backups(*, inventory: object, group: str | None, port: int) -> None:
+
+    inv = Inventory(inventory)
+    hosts = inv.get_host_names(group)
+
+    contact = f"{hosts[0]}:{port}"
+    client = Client(contact)
+    backups = await client.get_backups()
+
+    table = PrettyTable()
+    table.field_names = [
+        "Backup name",
+        "Start Time",
+        "Finish Time",
+        "Nodes",
+        # "Node list",
+        "Status",
+        "Type",
+        "#Objects",
+        "Size",
+    ]
+    for backup in backups:
+        # node_list = [f"{node.host} ({node.datacenter}/{node.rack})" for node in backup.nodes]
+        # if not node_list:
+        #     node_list = [""]
+
+        row = [
+            backup.backupName,
+            _time_fmt(backup.startTime),
+            _time_fmt(backup.finishTime),
+            f"{backup.finishedNodes}/{backup.totalNodes}",
+            # node_list[0],
+            _status_fmt(backup.status),
+            backup.backupType,
+            str(backup.totalObjects),
+            _size_fmt(backup.totalSize),
+        ]
+        table.add_row(row)
+
+        # remaining hosts
+        # for node in node_list[1:]:
+        #     row = [""] * len(table.field_names)
+        #     row[4] = node
+        #     table.add_row(row)
+
+    print(table)
+
+
+async def _delete_backup(*, inventory: object, name: str, group: str | None, port: int) -> None:
+
+    inv = Inventory(inventory)
+    hosts = inv.get_host_names(group)
+
+    contact = f"{hosts[0]}:{port}"
+    client = Client(contact)
+
+    await client.delete_backup(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 ansible
 yamllint
+prettytable
 hvac
+cassandra-medusa
+grpcio
+grpcio-health-checking

--- a/setup.sh
+++ b/setup.sh
@@ -3,3 +3,6 @@
 
 source ./_venv/bin/activate
 export ANSIBLE_CONFIG=$PWD/ansible.cfg
+
+export PATH=$PWD/bin:$PATH
+export PYTHONPATH=$PWD/python:$PYTHONPATH


### PR DESCRIPTION
Medusa is running as gRPC service in a container on each node. New CLI
is using client module to talk to the gRPC service to make/delete/list
backups. Backups are sent to the S3 bucket, this was tested for bot test
and production clusters. Restore has 