### PR TITLE
DM-51640: Enable logging to Loki

### DIFF
--- a/cassandra_cluster/group_vars/all.yml
+++ b/cassandra_cluster/group_vars/all.yml
@@ -81,3 +81,6 @@ backup_s3_port: 443
 
 # Jolokia is needed for both monitoring and backups.
 need_jolokia: "{{ use_monitoring or use_backups }}"
+
+# name of the Loki docker plugin.
+loki_plugin_name: grafana/loki-docker-driver:3.5.3-amd64

--- a/cassandra_cluster/roles/cassandra_configs/templates/cassandra-local.yaml.j2
+++ b/cassandra_cluster/roles/cassandra_configs/templates/cassandra-local.yaml.j2
@@ -22,7 +22,7 @@ concurrent_writes: 256
 row_cache_size: 0MiB
 
 file_cache_size: 2048MiB
-buffer_pool_use_heap_if_exhausted: true
+# buffer_pool_use_heap_if_exhausted: true  # deprecated
 
 memtable_heap_space: 4096MiB
 memtable_flush_writers: 8

--- a/cassandra_cluster/roles/cassandra_files/tasks/main.yml
+++ b/cassandra_cluster/roles/cassandra_files/tasks/main.yml
@@ -50,3 +50,9 @@
 - name: "Pull docker images"
   community.docker.docker_compose_v2_pull:
     project_src: "{{ deploy_docker_folder }}"
+
+- name: "Install loki docker plugin"
+  community.docker.docker_plugin:
+    alias: loki
+    plugin_name: "{{ loki_plugin_name }}"
+    state: enable

--- a/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
+++ b/cassandra_cluster/roles/cassandra_files/templates/docker-compose.yml.j2
@@ -42,12 +42,27 @@ services:
       JVM_EXTRA_OPTS: "-javaagent:/opt/cassandra/lib/jolokia-jvm.jar=port=8778,host=localhost"
       {%- endif %}
 
-    # Casandra logs a lot
     logging:
-      driver: json-file
+      driver: loki
       options:
-        max-size: "1g"
-        max-file: 10
+        loki-url: http://sdfloki.slac.stanford.edu:80/loki/api/v1/push
+        loki-pipeline-stages: |
+          - multiline:
+              firstline: '^(INFO|WARN|ERROR) .*'
+              max_wait_time: 3s
+          - regex:
+              expression: '^(?P<level>INFO|WARN|ERROR) *\[(?P<task>[^ ]*)\] (?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) (?P<message>(?s:.*))$'
+          - timestamp:
+              source: time
+              format: "2006-01-02 15:04:05.999"
+              location: "Etc/UTC"
+              action_on_failure: skip
+          - labels:
+              level:
+          - drop:
+              expression: '^INFO .*(SlabPoolCleaner|PerDiskMemtableFlushWriter|CompactionExecutor|NonPeriodicTasks.*Deleting sstable)'
+          - output:
+              source: message
 
     # run as regular user to avoid ownership changes by entrypoint, but
     # `data_dir` and files in it (if any) have to be owned by uid 999 already.
@@ -94,6 +109,29 @@ services:
         # uid: "999"
         # gid: "999"
         # mode: 0o400
+
+    logging:
+      driver: loki
+      options:
+        loki-url: http://sdfloki.slac.stanford.edu:80/loki/api/v1/push
+        loki-pipeline-stages: |
+          - multiline:
+              firstline: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<level>INFO|WARN|WARNING|ERROR|DEBUG): .*'
+              max_wait_time: 3s
+          - regex:
+              expression: '^\[(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?P<level>INFO|WARN|WARNING|ERROR|DEBUG): (?P<message>(?s:.*))$'
+          - timestamp:
+              source: time
+              format: "2006-01-02 15:04:05.999"
+              location: "Etc/UTC"
+              action_on_failure: skip
+          - labels:
+              level:
+          - drop:
+              source: level
+              value: "DEBUG"
+          - output:
+              source: message
 
 {% endif %}
 


### PR DESCRIPTION
Use Loki logging plugin to send logs from both cassandra and medusa to `sdfloki`. Filters are defined to reduce logging volumes.