### PR TITLE
DM-55315: Improve clone-keyspace script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Cluster-specific overrides for these variables appear in the file `cassandra_clu
 
 ## User accounts
 
-Cassandra services run from a special service account (`runbincas`) on each cluster host.
+Cassandra services run from a special service account (`rubincas`) on each cluster host.
 Kerberos authentication is used for connecting to cluster nodes via SSH:
 - user executing Ansible roles needs to have their principal added to `~rubincas/.k5login` on each node (message `usdf-help`),
 - user need to have a valid Kerberos token by executing `kinit`.
@@ -180,3 +180,45 @@ An example of full cluster restore:
 Single-node restore can be done by limiting set of nodes with `-l` option:
 
     ansible-playbook -i <inventory> -l sdfk8sk007 -e backup_name=backup-20251014 medusa-restore.yml
+
+
+## Backups with dsbulk
+
+In addition to `cassandra-medusa`-based backups there is an option to dump contents of the Cassandra tables in CSV format and restore the tables later.
+This approach uses [dsbulk tool](https://docs.datastax.com/en/dsbulk/overview/dsbulk-about.html) from DataStax.
+The speed of dump/restore with `dsbulk` is significantly lower than that of `cassandra-medusa`, but it provides more flexibility.
+In particular, `dsbulk` is the only option for restoring data into a cluster of different topology.
+
+A wrapper script in `bin/clone-keyspace` implements a number of options to simplify common operations:
+- selection of the tables to dump/restore,
+- bundling all dumped tables and metadata into a single tarball or a ZIP archive,
+- uploading dumped data to an S3 bucket.
+
+The volume of the data produced by dump operation can be very high, to store intermediate results a temporary location with sufficient free space will be needed.
+
+An example of dumping all `DiaObject*` tables to a ZIP archive on S3:
+
+    clone-keyspace -i inventory/apdb_dev.yaml --use-vault dump-keyspace \
+       -t 'DiaObject*' -j 4 -b zip --tmp-dir /sdf/scratch/rubin/apdb/... \
+       keyspace s3://profile@bucket/archives/DiaObject-20260701.zip
+
+As the other tools in this package `clone-keyspace` uses Ansible configuration for cluster-specific information.
+The `-i` option specifies an inventory file for Cassandra cluster.
+The `--use-vault` option will read Cassandra password from the Hashi Vault using path configured in Ansible.
+Uploading files to an S3 bucket requires credentials being setup in `~/.lsst/aws-credentials.ini`.
+
+In addition to compressed CSV files the dump includes two additional files:
+- `schema.json` with the schema of the dumped tables,
+- `manifest.txt` with the list of the files produced by the command.
+
+These files are used to restore the tables into an active Cassandra cluster.
+The data to be restored need to be copied to a local directory and unpacked in advance.
+
+And example of the restore command that restores a single table:
+
+    clone-keyspace -i inventory/apdb_dev.yaml --use-vault load-keyspace \
+      -t DiaObjectLast keyspace /sdf/scratch/rubin/apdb/some-directory
+
+The restore operation can cause significant resource use on server side, it needs to be monitored.
+If timeouts or errors happen during restore it is recommended to use `--max-concurrent-queries` option with a low setting (64 may be a good start).
+It is also recommended to restore one table at a time, with some delay between tables to reduce stress on cluster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "grpcio",
     "grpcio-health-checking",
     "parallel-ssh",
+    "lsst-resources",
 ]
 
 dynamic = ["version"]
@@ -89,8 +90,6 @@ line-length = 110
 target-version = "py311"
 exclude = [
     "__init__.py",
-    "lex.py",
-    "yacc.py",
 ]
 
 [tool.ruff.lint]
@@ -158,12 +157,6 @@ checks = [
 ]
 exclude = [
     "^test_.*",  # Do not test docstrings in test code.
-    '^spatial\..*',  # Do not test doc strings in the spatial.py test code.
-    '^lex\..*',  # Lexer
-    '^parserLex\.',  # Docstrings are not numpydoc
-    '^parserYacc\.',  # Docstrings are not numpydoc
-    '^commands\.',  # Click docstrings, not numpydoc
-    'butler.cli$',  # This is the main click command
     '^__init__$',
     '\._[a-zA-Z_]+$',  # Private methods.
 ]

--- a/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
+++ b/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
@@ -89,10 +89,20 @@ class CloneKeyspaceClI(CLI):
         parser.set_defaults(method=scripts.clone_list_keyspaces)
 
     def _create_dump_keyspace(self, subparsers: argparse._SubParsersAction) -> None:
-        parser = subparsers.add_parser("dump-keyspace", help="Dump keyspace to a folder.")
+        parser = subparsers.add_parser("dump-keyspace", help="Dump keyspace to a specified destination.")
         parser.add_argument("keyspace", type=str, help="Keyspace name.")
         parser.add_argument(
-            "destination", type=str, help="Folder to dump files, will be created if does not exist."
+            "destination", type=str, help="Where to dump files, a folder will be created if does not exist."
+        )
+        parser.add_argument(
+            "-t",
+            "--table-pattern",
+            dest="table_patterns",
+            type=str,
+            action="append",
+            default=[],
+            metavar="GLOB_PATTERN",
+            help=("Only dump specified tables, argument is a pattern that matches one or more table names."),
         )
         parser.add_argument(
             "-j",
@@ -115,9 +125,9 @@ class CloneKeyspaceClI(CLI):
             type=str,
             action="append",
             default=[],
+            metavar="GLOB_PATTERN",
             help=(
-                "Only restore specified tables, argument is a pattern that matches one or more table names, "
-                "can be used multiple times."
+                "Only restore specified tables, argument is a pattern that matches one or more table names."
             ),
         )
         parser.add_argument(
@@ -165,10 +175,10 @@ class CloneKeyspaceClI(CLI):
 
     def _use_vault(self, cliargs: dict[str, Any], host_vars: dict[str, Any]) -> None:
         """Retrieve username and password from the Vault."""
-        if host_vars["credentials_source"] != "hashi_vault":
+        if host_vars["make_credentials_source"] != "hashi_vault":
             raise AnsibleError(
-                "Cannot read credentials from the vault as credentials_source "
-                f"is set to unexpected value {host_vars['credentials_source']}."
+                "Cannot read credentials from the vault as make_credentials_source "
+                f"is set to unexpected value {host_vars['make_credentials_source']}."
             )
 
         # Service URL comes from $VAULT_ADDR

--- a/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
+++ b/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
@@ -90,9 +90,16 @@ class CloneKeyspaceClI(CLI):
 
     def _create_dump_keyspace(self, subparsers: argparse._SubParsersAction) -> None:
         parser = subparsers.add_parser("dump-keyspace", help="Dump keyspace to a specified destination.")
-        parser.add_argument("keyspace", type=str, help="Keyspace name.")
+        parser.add_argument("keyspace", type=str, help="Keyspace name to dump.")
         parser.add_argument(
-            "destination", type=str, help="Where to dump files, a folder will be created if does not exist."
+            "destination",
+            type=str,
+            help=(
+                "Where to dump files, this can be either a local filesystem path or URL on remote (S3) "
+                "store. Local folder will be created if does not exist. If option --bundle is not used "
+                "then destination must be a directory-like path. If --bundle is specified then path must "
+                "include extension matching the bundle type (.tar or .zip)."
+            ),
         )
         parser.add_argument(
             "-t",
@@ -112,10 +119,32 @@ class CloneKeyspaceClI(CLI):
             metavar="COUNT",
             help="Number of concurrent jobs, default: %(default)s.",
         )
+        parser.add_argument(
+            "-b",
+            "--bundle",
+            type=str,
+            default=None,
+            choices=("tar", "zip"),
+            metavar="ARCHIVE_TYPE",
+            help=(
+                "Bundle all dumped files into a single archive, either tar or zip. "
+                "Destination must be file URL or local path with a matching extension."
+            ),
+        )
+        parser.add_argument(
+            "--tmp-dir",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help=(
+                "Directory to store intermediate files, will be created if does not exist. "
+                "Must be specified when `--bundle` is given or when destination is a remote (S3) path."
+            ),
+        )
         parser.set_defaults(method=scripts.clone_dump_keyspace)
 
     def _create_load_keyspace(self, subparsers: argparse._SubParsersAction) -> None:
-        parser = subparsers.add_parser("load-keyspace", help="Load keyspace deta from a folder.")
+        parser = subparsers.add_parser("load-keyspace", help="Load keyspace data from a folder.")
         parser.add_argument("keyspace", type=str, help="Keyspace name.")
         parser.add_argument("folder", type=str, help="Folder with keyspace data created by dump-keyspace.")
         parser.add_argument(
@@ -146,7 +175,7 @@ class CloneKeyspaceClI(CLI):
             type=str,
             default=None,
             metavar="COUNT",
-            help="Limit number cincurrent queries, one of AUTO, <N>, <N>C default: AUTO.",
+            help="Limit number concurrent queries, one of AUTO, <N>, <N>C default: AUTO.",
         )
         parser.add_argument("--dry-run", action="store_true", help="Do not restore, only print actions.")
         parser.set_defaults(method=scripts.clone_load_keyspace)

--- a/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
+++ b/python/lsst/dax/apdb_deploy/cli/clone_keyspace.py
@@ -66,7 +66,7 @@ class CloneKeyspaceClI(CLI):
         self.parser.add_argument(
             "--use-vault",
             action="store_true",
-            help="Use Vault to access credentials.",
+            help="Use Hashi Vault to retrieve Cassandra credentials.",
         )
         self.parser.add_argument(
             "--username",

--- a/python/lsst/dax/apdb_deploy/scripts/_clone_keyspace.py
+++ b/python/lsst/dax/apdb_deploy/scripts/_clone_keyspace.py
@@ -110,6 +110,7 @@ def clone_dump_keyspace(
     port: int,
     username: str | None,
     password: str | None,
+    table_patterns: list[str],
     jobs: int,
 ) -> None:
     """Dump keyspace schema and data to a specified directory.
@@ -128,6 +129,9 @@ def clone_dump_keyspace(
         Cassandra user name.
     password : `str` or `None`
         Cassandra password.
+    table_patterns : `list` [`str`]
+        List of patterns, tables will be dumped if they match one of the
+        patterns, if empty then all tables will be dumped.
     jobs : `int`
         Number of concurrent jobs.
     """
@@ -139,6 +143,7 @@ def clone_dump_keyspace(
             port=port,
             username=username,
             password=password,
+            table_patterns=table_patterns,
             jobs=jobs,
         )
     )
@@ -175,7 +180,7 @@ def clone_load_keyspace(
     password : `str` or `None`
         Cassandra password.
     table_patterns : `list` [`str`]
-        List of patterns, tables will be loaded if the matcgh one of the
+        List of patterns, tables will be loaded if they match one of the
         patterns, if empty then all tables will be loaded.
     skip_existing_tables : `bool`
         If `True` then loading will be skipped for the tables that already
@@ -227,6 +232,7 @@ async def _dump_keyspace(
     port: int,
     username: str | None,
     password: str | None,
+    table_patterns: list[str],
     jobs: int,
 ) -> None:
     # Need dsbulk, check that it can be found.
@@ -249,6 +255,14 @@ async def _dump_keyspace(
             tables = sorted(_keyspace_tables(session, keyspace))
             if not tables:
                 raise ValueError(f"Keyspace {keyspace!r} does not have any tables.")
+            if table_patterns:
+                tables_to_dump = []
+                for pattern in table_patterns:
+                    if matching_tables := fnmatch.filter(tables, pattern):
+                        tables_to_dump += matching_tables
+                    else:
+                        raise ValueError(f"Pattern {pattern!r} does not match any table name.")
+                tables = tables_to_dump
 
             # Dump schema for all tables but do not include CREATE KEYSPACE.
             schema = {}

--- a/python/lsst/dax/apdb_deploy/scripts/_clone_keyspace.py
+++ b/python/lsst/dax/apdb_deploy/scripts/_clone_keyspace.py
@@ -30,13 +30,21 @@ import os
 import re
 import shlex
 import subprocess
+import tarfile
+import tempfile
 import time
+import zipfile
+from collections.abc import Iterator
+from contextlib import ExitStack
 from string import Template
+from typing import Literal
 
 from cassandra.auth import AuthProvider, PlainTextAuthProvider
 from cassandra.cluster import Cluster, Session
 from cassandra.policies import RoundRobinPolicy
 from prettytable import PrettyTable
+
+from lsst.resources import ResourcePath
 
 _LOG = logging.getLogger(__name__)
 
@@ -45,44 +53,8 @@ _EXISTS_PLACEHOLDER = "${IF_NOT_EXISTS}"
 
 _CREATE_TABLE_RE = re.compile("(.*CREATE TABLE )([^.]+)([.].*)", re.DOTALL)
 
-
-def _check_dsbulk() -> None:
-    """Check that dsbulk application can be executed."""
-    try:
-        subprocess.run(("dsbulk", "--version"), capture_output=True)
-    except Exception as exc:
-        raise RuntimeError(f"Failed to execute dsbulk, check $PATH: {exc}") from None
-
-
-def _make_auth_provider(username: str | None, password: str | None) -> AuthProvider | None:
-    """Make Cassandra authentication provider instance."""
-    if username and password:
-        return PlainTextAuthProvider(username=username, password=password)
-    return None
-
-
-def _make_cluster(hosts: list[str], port: int, username: str | None, password: str | None) -> Cluster:
-    # Use first two hosts for contact points.
-    contact_points = hosts[:2]
-    return Cluster(
-        contact_points=contact_points,
-        port=port,
-        auth_provider=_make_auth_provider(username, password),
-        load_balancing_policy=RoundRobinPolicy(),
-        protocol_version=5,
-    )
-
-
-def _keyspace_tables(session: Session, keyspace: str) -> list[str]:
-    """Get the list of tables in a keyspace."""
-    query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = '%s'"
-    result = session.execute(query, [keyspace])
-    return [row[0] for row in result]
-
-
-def _replace_ks_name(statement: str) -> str:
-    """Replace keyspace name in CREATE TABLE with a placeholder"""
-    return _CREATE_TABLE_RE.sub(f"\\1{_EXISTS_PLACEHOLDER} {_KS_PLACEHOLDER}\\3", statement)
+# Location of the dsbulk log files relative to other dumped files.
+_DSBULK_LOG = "_dsbulk_log"
 
 
 def clone_list_keyspaces(*, hosts: list[str], port: int, username: str | None, password: str | None) -> None:
@@ -112,15 +84,19 @@ def clone_dump_keyspace(
     password: str | None,
     table_patterns: list[str],
     jobs: int,
+    bundle: Literal["tar", "zip"] | None,
+    tmp_dir: str | None,
 ) -> None:
-    """Dump keyspace schema and data to a specified directory.
+    """Dump keyspace schema and data to a specified directory, archive, or
+    a remote URL.
 
     Parameters
     ----------
     keyspace : `str`
         Keyspace name.
     destination : `str`
-        Folder name to store data to, will be created if does not exist.
+        Local folder name, archive name, or a remote URL to store data to.
+        Folder will be created if does not exist.
     hosts : `list` [`str`]
         Names of the hosts in the cluster.
     port : `int`
@@ -134,19 +110,30 @@ def clone_dump_keyspace(
         patterns, if empty then all tables will be dumped.
     jobs : `int`
         Number of concurrent jobs.
+    bundle : `str` or `None`
+        If not `None` then bundle all files into a single archive, can be
+        either "tar" or "zip".
+    tmp_dir : `str` or `None`
+        Location of temporary folder to store intermediate files, must be
+        specified if ``bundle`` is not `None`or when ``destination`` is a
+        remote URL; ignored otherwise.
     """
-    asyncio.run(
-        _dump_keyspace(
-            keyspace=keyspace,
-            destination=destination,
-            hosts=hosts,
-            port=port,
-            username=username,
-            password=password,
-            table_patterns=table_patterns,
-            jobs=jobs,
+    with ExitStack() as exit_stack:
+        asyncio.run(
+            _dump_keyspace(
+                keyspace=keyspace,
+                destination=destination,
+                hosts=hosts,
+                port=port,
+                username=username,
+                password=password,
+                table_patterns=table_patterns,
+                jobs=jobs,
+                bundle=bundle,
+                tmp_dir=tmp_dir,
+                exit_stack=exit_stack,
+            )
         )
-    )
 
 
 def clone_load_keyspace(
@@ -234,50 +221,55 @@ async def _dump_keyspace(
     password: str | None,
     table_patterns: list[str],
     jobs: int,
+    bundle: Literal["tar", "zip"] | None,
+    tmp_dir: str | None,
+    exit_stack: ExitStack,
 ) -> None:
     # Need dsbulk, check that it can be found.
     _check_dsbulk()
 
+    # Validate bundle mode destination path.
+    dst_resource = ResourcePath(destination)
+    tmp_path: ResourcePath | None = None
+    if bundle is not None:
+        if bundle not in ("tar", "zip"):
+            raise ValueError(f"Unexpected bundle type: {bundle}.")
+        if dst_resource.isdir():
+            raise ValueError(f"Destination {dst_resource!r} cannot be a directory.")
+        if dst_resource.getExtension().lower() != f".{bundle}":
+            raise ValueError(
+                f"Destination extension {dst_resource.getExtension()!r} "
+                f"does not match bundle type {bundle!r}."
+            )
+    else:
+        if not dst_resource.isdir():
+            raise ValueError(f"Destination {dst_resource!r} must be a directory.")
+
+    # Make a temporary folder from which we can copy/transfer files.
+    if bundle is not None or not dst_resource.isLocal:
+        if not tmp_dir:
+            raise ValueError("Temporary directory must be specified.")
+        os.makedirs(tmp_dir, exist_ok=True)
+        temp_directory = tempfile.TemporaryDirectory(dir=tmp_dir)
+        exit_stack.enter_context(temp_directory)
+        tmp_path = ResourcePath(temp_directory.name)
+
+    dump_location = tmp_path if tmp_path is not None else dst_resource
+
     # Create destination if does not exist.
-    dsbulk_logs = os.path.join(destination, "_dsbulk_log")
-    os.makedirs(dsbulk_logs, exist_ok=True)
+    dsbulk_logs = dump_location.join(_DSBULK_LOG)
+    dsbulk_logs.mkdir()
     manifest: list[str] = []
 
-    # Check that keyspace exists.
-    with _make_cluster(hosts, port, username, password) as cluster:
-        with cluster.connect() as session:
-            query = "SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = '%s'"
-            result = session.execute(query, [keyspace])
-            if not result:
-                raise ValueError(f"Keyspace {keyspace!r} does not exist.")
-
-            # Get the list of tables.
-            tables = sorted(_keyspace_tables(session, keyspace))
-            if not tables:
-                raise ValueError(f"Keyspace {keyspace!r} does not have any tables.")
-            if table_patterns:
-                tables_to_dump = []
-                for pattern in table_patterns:
-                    if matching_tables := fnmatch.filter(tables, pattern):
-                        tables_to_dump += matching_tables
-                    else:
-                        raise ValueError(f"Pattern {pattern!r} does not match any table name.")
-                tables = tables_to_dump
-
-            # Dump schema for all tables but do not include CREATE KEYSPACE.
-            schema = {}
-            for table in tables:
-                query = f'DESCRIBE "{keyspace}"."{table}"'
-                result = session.execute(query)
-                table_schema = result.one().create_statement
-                table_schema = _replace_ks_name(table_schema)
-                schema[table] = table_schema
-            with open(os.path.join(destination, "schema.json"), "w") as out:
-                json.dump(schema, out)
-            manifest.append("schema.json")
+    # Get schema for all tables to be dumped.
+    schema = _table_schema(keyspace, hosts, port, username, password, table_patterns)
+    with open(dump_location.join("schema.json").ospath, "w") as out:
+        json.dump(schema, out)
+    manifest.append("schema.json")
 
     t0 = time.time()
 
+    tables = sorted(schema)
     n_tasks = max(jobs, 1)
     tasks: list[asyncio.Task] = []
     exceptions = []
@@ -289,7 +281,7 @@ async def _dump_keyspace(
                     port=port,
                     keyspace=keyspace,
                     table=tables.pop(0),
-                    destination=destination,
+                    destination=dump_location.ospath,
                     username=username,
                     password=password,
                 )
@@ -310,13 +302,38 @@ async def _dump_keyspace(
         raise BaseExceptionGroup("One or more operations failed", exceptions)
 
     # Finally write manifest, it is a marker that dump is complete.
-    with open(os.path.join(destination, "manifest.txt"), "w") as out:
+    with open(dump_location.join("manifest.txt").ospath, "w") as out:
         for name in sorted(manifest):
             print(name, file=out)
 
     t1 = time.time()
 
     _LOG.info("Total time for dump: %.2f sec", t1 - t0)
+
+    if bundle is not None:
+        local_bundle_path = dst_resource
+        if not dst_resource.isLocal:
+            local_bundle_path = dump_location.join(dst_resource.basename())
+
+        if bundle == "tar":
+            _make_tarball(dump_location, manifest, local_bundle_path)
+        elif bundle == "zip":
+            _make_zip(dump_location, manifest, local_bundle_path)
+        else:
+            raise ValueError(f"Unexpected bundle type {bundle}")
+
+        if local_bundle_path != dst_resource:
+            _LOG.info("Transferring bundle to %s", dst_resource)
+            dst_resource.transfer_from(local_bundle_path, transfer="move")
+
+    elif not dst_resource.isLocal:
+        # Transfer individual files to remote.
+        _LOG.info("Transferring files to %s", dst_resource)
+        for local_path in _walk_files(dump_location):
+            rel_path = local_path.relative_to(dump_location)
+            assert rel_path is not None, "must be relative"
+            remote_path = dst_resource.join(rel_path)
+            remote_path.transfer_from(local_path, transfer="move")
 
 
 async def _dump_table(
@@ -332,7 +349,7 @@ async def _dump_table(
     """Dump table contents as CSV file."""
     output_file = f"{table}.csv.gz"
     output_path = os.path.join(destination, output_file)
-    log_dir = os.path.join(destination, "_dsbulk_log")
+    log_dir = os.path.join(destination, _DSBULK_LOG)
     os.makedirs(log_dir, exist_ok=True)
 
     # Command to dump table data in CSV format to stdout.
@@ -540,7 +557,7 @@ async def _load_table(
     if dry_run:
         return
 
-    log_dir = os.path.join(folder, "_dsbulk_log")
+    log_dir = os.path.join(folder, _DSBULK_LOG)
     os.makedirs(log_dir, exist_ok=True)
 
     # Command to load table data in CSV format from stdin.
@@ -586,3 +603,150 @@ async def _load_table(
         os.close(fd)
 
     _LOG.info("Finished restoring table %s", table)
+
+
+def _walk_files(path: ResourcePath) -> Iterator[ResourcePath]:
+    """Find all files in a specified directory."""
+    for rp, _, files in path.walk():
+        for file_name in files:
+            yield rp.join(file_name)
+
+
+def _make_tarball(dump_location: ResourcePath, manifest: list[str], local_bundle_path: ResourcePath) -> None:
+    """Make a tarball with all files in manifest plus manifest itself and
+    dsbulk log files.
+    """
+    # We are not compressing tar, bulk of data is already compressed.
+    _LOG.info("Creating tarball %s", local_bundle_path)
+    members = manifest + ["manifest.txt", _DSBULK_LOG]
+    try:
+        with tarfile.open(local_bundle_path.ospath, "w") as tar:
+            for member in members:
+                member_path = dump_location.join(member)
+                tar.add(member_path.ospath, member)
+                # Delete file after adding it to a tarball, could avoid running
+                # out of disk space on large backups. We do not care to remove
+                # dsbulk logs as they are small and will be removed when tmp
+                # directory is removed.
+                if member != _DSBULK_LOG:
+                    member_path.remove()
+    except Exception:
+        # Delete partial tarball on any errors.
+        try:
+            local_bundle_path.remove()
+        except Exception:
+            pass
+        raise
+
+
+def _make_zip(dump_location: ResourcePath, manifest: list[str], local_bundle_path: ResourcePath) -> None:
+    """Make a zip archive with all files in manifest plus manifest itself and
+    dsbulk log files.
+    """
+    _LOG.info("Creating zip archive %s", local_bundle_path)
+    members = manifest + ["manifest.txt"]
+    try:
+        # We are not compressing zip, bulk of data is already compressed.
+        with zipfile.ZipFile(local_bundle_path.ospath, "w", compression=zipfile.ZIP_STORED) as archive:
+            for member in members:
+                member_path = dump_location.join(member)
+                archive.write(member_path.ospath, member)
+                # Delete file after adding it to archive.
+                member_path.remove()
+
+            # And all dsbulk log files.
+            for local_path in _walk_files(dump_location.join(_DSBULK_LOG)):
+                archive.write(local_path.ospath, local_path.relative_to(dump_location))
+
+    except Exception:
+        # Delete partial archive on any errors.
+        try:
+            local_bundle_path.remove()
+        except Exception:
+            pass
+        raise
+
+
+def _table_schema(
+    keyspace: str,
+    hosts: list[str],
+    port: int,
+    username: str | None,
+    password: str | None,
+    table_patterns: list[str],
+) -> dict[str, str]:
+    """Extract schema definition for all tables to be dumped.
+
+    Returns a dict with a table name as a key and "CREATE TABLE" template as a
+    value.
+    """
+    with _make_cluster(hosts, port, username, password) as cluster:
+        with cluster.connect() as session:
+            # Check that keyspace exists.
+            query = "SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = '%s'"
+            result = session.execute(query, [keyspace])
+            if not result:
+                raise ValueError(f"Keyspace {keyspace!r} does not exist.")
+
+            # Get the list of tables.
+            tables = sorted(_keyspace_tables(session, keyspace))
+            if not tables:
+                raise ValueError(f"Keyspace {keyspace!r} does not have any tables.")
+            if table_patterns:
+                tables_to_dump: set[str] = set()
+                for pattern in table_patterns:
+                    if matching_tables := fnmatch.filter(tables, pattern):
+                        tables_to_dump.update(matching_tables)
+                    else:
+                        raise ValueError(f"Pattern {pattern!r} does not match any table name.")
+                tables = sorted(tables_to_dump)
+
+            # Dump schema for all tables but do not include CREATE KEYSPACE.
+            schema = {}
+            for table in tables:
+                query = f'DESCRIBE "{keyspace}"."{table}"'
+                result = session.execute(query)
+                table_schema = result.one().create_statement
+                table_schema = _replace_ks_name(table_schema)
+                schema[table] = table_schema
+
+            return schema
+
+
+def _check_dsbulk() -> None:
+    """Check that dsbulk application can be executed."""
+    try:
+        subprocess.run(("dsbulk", "--version"), capture_output=True)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to execute dsbulk, check $PATH: {exc}") from None
+
+
+def _make_auth_provider(username: str | None, password: str | None) -> AuthProvider | None:
+    """Make Cassandra authentication provider instance."""
+    if username and password:
+        return PlainTextAuthProvider(username=username, password=password)
+    return None
+
+
+def _make_cluster(hosts: list[str], port: int, username: str | None, password: str | None) -> Cluster:
+    # Use first two hosts for contact points.
+    contact_points = hosts[:2]
+    return Cluster(
+        contact_points=contact_points,
+        port=port,
+        auth_provider=_make_auth_provider(username, password),
+        load_balancing_policy=RoundRobinPolicy(),
+        protocol_version=5,
+    )
+
+
+def _keyspace_tables(session: Session, keyspace: str) -> list[str]:
+    """Get the list of tables in a keyspace."""
+    query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = '%s'"
+    result = session.execute(query, [keyspace])
+    return [row[0] for row in result]
+
+
+def _replace_ks_name(statement: str) -> str:
+    """Replace keyspace name in CREATE TABLE with a placeholder"""
+    return _CREATE_TABLE_RE.sub(f"\\1{_EXISTS_PLACEHOLDER} {_KS_PLACEHOLDER}\\3", statement)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ cassandra-medusa
 grpcio
 grpcio-health-checking
 parallel-ssh
+lsst-resources


### PR DESCRIPTION
`clone-keyspace` can now dump a subset of tables, bundle dumps into tar/zip archives, and send everything to S3.